### PR TITLE
Added: permissions for MT queues to be accessed by Iridium

### DIFF
--- a/templates/iridium-cloud-connect-sbd.template.yaml
+++ b/templates/iridium-cloud-connect-sbd.template.yaml
@@ -88,6 +88,13 @@ Resources:
             Effect: Allow
             Action:
               - sqs:SendMessage
+              - sqs:ReceiveMessage
+              - sqs:DeleteMessage
+            Resource: !Sub "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${MobileTerminatedSQSQueue.QueueName}"
+          -
+            Effect: Allow
+            Action:
+              - sqs:SendMessage
             Resource: !Sub "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${MobileTerminatedConfirmationSQSQueue.QueueName}"
           -
             Effect: Allow


### PR DESCRIPTION
Cloudformation template lacks permissions for the Mobile Terminated queue. This situation prevents Iridium Cloud Connect to process outgoing messages.

This PR adds SendMessage, DeleteMessage and ReceiveMessage to the MobileTerminatedSQSQueue.